### PR TITLE
Adding cost centre label tag to cloud billing exporter

### DIFF
--- a/billing_collector.go
+++ b/billing_collector.go
@@ -34,9 +34,10 @@ type BillingCollector struct {
 	AWSOwnerTag      *string
 	AWSProjectIDTag  *string
 
-	GCPReportPrefix *string
-	GCPBucketName   *string
-	GCPOwnerLabel   *string
+	GCPReportPrefix    *string
+	GCPBucketName      *string
+	GCPOwnerLabel      *string
+	GCPCostCentreLabel *string
 
 	ShowVersion   *bool
 	ListenAddress *string
@@ -51,6 +52,7 @@ func (b *BillingCollector) parseFlags() {
 	b.GCPReportPrefix = flag.String("gcp-billing.report-prefix", "my-billing", "Report name prefix for GCP billing.")
 	b.GCPBucketName = flag.String("gcp-billing.bucket-name", "", "Bucket name that stores GCP JSON billing reports.")
 	b.GCPOwnerLabel = flag.String("gcp-billing.owner-label", "owner-base32", "Name of the owner label, which contains the owner in base32 encoding.")
+	b.GCPCostCentreLabel = flag.String("gcp-billing.costcentre-label", "cost_centre", "Name of the cost centre label, which contains the cost centre")
 
 	b.AWSRegion = flag.String("aws-billing.region", "eu-west-1", "Region name for AWS billing bucket.")
 	b.AWSBucketName = flag.String("aws-billing.bucket-name", "", "Bucket name that stores AWS billing reports.")
@@ -89,7 +91,7 @@ func (b *BillingCollector) Run() {
 			Name: prometheus.BuildFQName(Namespace, "billing", "monthly_costs"),
 			Help: "Billed costs per calendar month.",
 		},
-		[]string{"cloud", "currency", "account", "service", "path", "owner"},
+		[]string{"cloud", "currency", "account", "service", "path", "owner", "cost_centre"},
 	)
 
 	if *b.AWSBucketName != "" {
@@ -119,6 +121,7 @@ func (b *BillingCollector) Run() {
 			*b.GCPBucketName,
 			*b.GCPReportPrefix,
 			*b.GCPOwnerLabel,
+			*b.GCPCostCentreLabel,
 		)
 		if err := c.Test(); err != nil {
 			log.Error(err)

--- a/billing_collector.go
+++ b/billing_collector.go
@@ -34,10 +34,11 @@ type BillingCollector struct {
 	AWSOwnerTag      *string
 	AWSProjectIDTag  *string
 
-	GCPReportPrefix    *string
-	GCPBucketName      *string
-	GCPOwnerLabel      *string
-	GCPCostCentreLabel *string
+	GCPReportPrefix     *string
+	GCPBucketName       *string
+	GCPOwnerLabel       *string
+	GCPCostCentreLabel  *string
+	GCPProjectTypeLabel *string
 
 	ShowVersion   *bool
 	ListenAddress *string
@@ -53,6 +54,7 @@ func (b *BillingCollector) parseFlags() {
 	b.GCPBucketName = flag.String("gcp-billing.bucket-name", "", "Bucket name that stores GCP JSON billing reports.")
 	b.GCPOwnerLabel = flag.String("gcp-billing.owner-label", "owner-base32", "Name of the owner label, which contains the owner in base32 encoding.")
 	b.GCPCostCentreLabel = flag.String("gcp-billing.costcentre-label", "cost_centre", "Name of the cost centre label, which contains the cost centre")
+	b.GCPProjectTypeLabel = flag.String("gcp-billing.project-type-label", "type", "Name of the type label which describes the GPC project")
 
 	b.AWSRegion = flag.String("aws-billing.region", "eu-west-1", "Region name for AWS billing bucket.")
 	b.AWSBucketName = flag.String("aws-billing.bucket-name", "", "Bucket name that stores AWS billing reports.")
@@ -91,7 +93,7 @@ func (b *BillingCollector) Run() {
 			Name: prometheus.BuildFQName(Namespace, "billing", "monthly_costs"),
 			Help: "Billed costs per calendar month.",
 		},
-		[]string{"cloud", "currency", "account", "service", "path", "owner", "cost_centre"},
+		[]string{"cloud", "currency", "account", "service", "path", "owner", "cost_centre", "type"},
 	)
 
 	if *b.AWSBucketName != "" {
@@ -122,6 +124,7 @@ func (b *BillingCollector) Run() {
 			*b.GCPReportPrefix,
 			*b.GCPOwnerLabel,
 			*b.GCPCostCentreLabel,
+			*b.GCPProjectTypeLabel,
 		)
 		if err := c.Test(); err != nil {
 			log.Error(err)

--- a/gcp/gcp_billing.go
+++ b/gcp/gcp_billing.go
@@ -68,12 +68,12 @@ type GCPBilling struct {
 	resourcesMetadata  *resourcesMetadata
 }
 
-func NewGCPBilling(metric *prometheus.CounterVec, bucketName, reportPrefix, ownerLabel string, costCentreLabel string) *GCPBilling {
+func NewGCPBilling(metric *prometheus.CounterVec, bucketName, reportPrefix, ownerLabel string, costCentreLabel string, projectTypeLabel string) *GCPBilling {
 	return &GCPBilling{
 		MetricMonthlyCosts: metric,
 		BucketName:         bucketName,
 		ReportPrefix:       reportPrefix,
-		resourcesMetadata:  newResourcesMetadata().WithResourceLabels(ownerLabel, costCentreLabel),
+		resourcesMetadata:  newResourcesMetadata().WithResourceLabels(ownerLabel, costCentreLabel, projectTypeLabel),
 		clock:              realClock{},
 		metricValues:       map[string]float64{},
 	}
@@ -319,11 +319,12 @@ func (g *GCPBilling) Query() error {
 
 	// write them into the metrics
 	for _, elem := range elems {
-		var owner, costcentre, path string
+		var owner, costcentre, projectType, path string
 		metadata := g.resourcesMetadata.projectByID(elem.ProjectID)
 		if metadata != nil {
 			owner = metadata.owner
 			costcentre = metadata.costCentre
+			projectType = metadata.projectType
 			path = strings.Join(g.resourcesMetadata.path(metadata), "/")
 		}
 
@@ -335,6 +336,7 @@ func (g *GCPBilling) Query() error {
 			path,
 			owner,
 			costcentre,
+			projectType,
 		)
 		key := groupByProjectIDServiceCurrency(elem)
 		if _, ok := g.metricValues[key]; !ok {


### PR DESCRIPTION
This pull request implements the cost centre label so that a user can have visibility on what project belongs to which cost centre assuming they have the labels in place to support the cost centre tag.